### PR TITLE
Make shown modal content temporary to ensure its not cached

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    katalyst-kpop (2.0.7)
+    katalyst-kpop (2.0.8)
 
 GEM
   remote: https://rubygems.org/

--- a/app/assets/javascripts/controllers/kpop_controller.js
+++ b/app/assets/javascripts/controllers/kpop_controller.js
@@ -7,7 +7,10 @@ export default class KpopController extends Controller {
     open: Boolean,
   };
 
-  contentTargetConnected() {
+  contentTargetConnected(target) {
+    // Set the modal content to temporary to ensure its omitted when caching the page
+    target.setAttribute("data-turbo-temporary", "");
+
     // When switching modals a target may connect while scrim is already open
     if (this.openValue) return;
 

--- a/app/helpers/kpop_helper.rb
+++ b/app/helpers/kpop_helper.rb
@@ -18,7 +18,6 @@ module KpopHelper
     html_attributes[:data]                   ||= {}
     html_attributes[:data][:controller]      = "kpop"
     html_attributes[:data][:action]          = "scrim:hide@window->kpop#dismiss"
-    html_attributes[:data][:turbo_temporary] = ""
 
     turbo_frame_tag("kpop", **html_attributes) do
       capture(&block) if block

--- a/lib/katalyst/kpop/version.rb
+++ b/lib/katalyst/kpop/version.rb
@@ -2,6 +2,6 @@
 
 module Katalyst
   module Kpop
-    VERSION = "2.0.7"
+    VERSION = "2.0.8"
   end
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@katalyst-interactive/kpop",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "description": "Stimulus controllers for the katalyst-kpop Ruby Gem",
   "main": "app/assets/builds/katalyst/kpop.js",
   "style": "app/assets/builds/katalyst/kpop.css",


### PR DESCRIPTION
This fixes an issue where setting the turbo-frame to temporary would omit it from the cache and not be there on a restoration visit. Resulting in the modal not showing when clicking a kpop_link_to