### PR TITLE
Fix - instantly scroll back to position instead of animating

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    katalyst-kpop (2.0.8)
+    katalyst-kpop (2.0.9)
 
 GEM
   remote: https://rubygems.org/

--- a/app/assets/javascripts/controllers/scrim_controller.js
+++ b/app/assets/javascripts/controllers/scrim_controller.js
@@ -145,7 +145,7 @@ export default class ScrimController extends Controller {
     resetStyle(this.element, "z-index", null);
     resetStyle(document.body, "position", null);
     resetStyle(document.body, "top", null);
-    window.scrollTo(0, this.scrollY);
+    window.scrollTo({ left: 0, top: this.scrollY, behavior: "instant" });
 
     delete this.scrollY;
     delete this.previousPosition;

--- a/lib/katalyst/kpop/version.rb
+++ b/lib/katalyst/kpop/version.rb
@@ -2,6 +2,6 @@
 
 module Katalyst
   module Kpop
-    VERSION = "2.0.8"
+    VERSION = "2.0.9"
   end
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@katalyst-interactive/kpop",
-  "version": "2.0.8",
+  "version": "2.0.9",
   "description": "Stimulus controllers for the katalyst-kpop Ruby Gem",
   "main": "app/assets/builds/katalyst/kpop.js",
   "style": "app/assets/builds/katalyst/kpop.css",


### PR DESCRIPTION
When the scrim closes we called ScrollTo which depending on browser support would default to `scroll-behaviour:smooth`. Forcing the scroll reset of the body content to be instant instead.