### PR TITLE
Side panel modal

### DIFF
--- a/app/assets/javascripts/controllers/kpop/close_controller.js
+++ b/app/assets/javascripts/controllers/kpop/close_controller.js
@@ -1,0 +1,10 @@
+import { Controller } from "@hotwired/stimulus";
+import { Turbo } from "@hotwired/turbo-rails";
+
+export default class Kpop__CloseController extends Controller {
+  static outlets = ["kpop--frame"];
+
+  kpopFrameOutletConnected(frame) {
+    frame.dismiss();
+  }
+}

--- a/app/assets/javascripts/controllers/kpop/frame_controller.js
+++ b/app/assets/javascripts/controllers/kpop/frame_controller.js
@@ -12,10 +12,15 @@ export default class Kpop__FrameController extends Controller {
   scrimOutletConnected(scrim) {
     if (DEBUG) console.debug("frame:scrim-connected");
 
+    this.scrimConnected = true;
+
     // return if already initialized
     if (this.openValue) return;
 
-    // Capture the scrim and then show the content
+    // modal controller may not have loaded yet (lazy loading)
+    if (!this.modalConnected) return;
+
+    // Capture the scrim and then show the content, if present
     if (this.hasModalOutlet) {
       this.#openModal(scrim, this.modalOutlet);
     }
@@ -24,13 +29,16 @@ export default class Kpop__FrameController extends Controller {
   modalOutletConnected(modal) {
     if (DEBUG) console.debug("frame:modal-connected");
 
+    this.modalConnected = true;
+
     // When switching modals a target may connect while scrim is already open
     if (this.openValue) return;
 
+    // scrim controller may not have loaded yet (lazy loading)
+    if (!this.scrimConnected) return;
+
     // Capture the scrim and then show the content if the scrim is ready
-    if (this.hasScrimOutlet) {
-      this.#openModal(this.scrimOutlet, modal);
-    }
+    this.#openModal(this.scrimOutlet, modal);
   }
 
   modalOutletDisconnected(_) {

--- a/app/assets/javascripts/controllers/kpop/frame_controller.js
+++ b/app/assets/javascripts/controllers/kpop/frame_controller.js
@@ -1,6 +1,6 @@
 import { Controller } from "@hotwired/stimulus";
 
-const DEBUG = false;
+const DEBUG = true;
 
 export default class Kpop__FrameController extends Controller {
   static outlets = ["scrim"];
@@ -10,7 +10,7 @@ export default class Kpop__FrameController extends Controller {
   };
 
   scrimOutletConnected(scrim) {
-    if (DEBUG) console.debug("scrim connected");
+    if (DEBUG) console.debug("frame:scrim-connected");
 
     // return if already initialized
     if (this.openValue) return;
@@ -22,7 +22,7 @@ export default class Kpop__FrameController extends Controller {
   }
 
   modalOutletConnected(modal) {
-    if (DEBUG) console.debug("modal connected");
+    if (DEBUG) console.debug("frame:modal-connected");
 
     // When switching modals a target may connect while scrim is already open
     if (this.openValue) return;
@@ -34,7 +34,7 @@ export default class Kpop__FrameController extends Controller {
   }
 
   modalOutletDisconnected(_) {
-    if (DEBUG) console.debug("modal disconnect");
+    if (DEBUG) console.debug("frame:modal-disconnect");
 
     // When switching modals there may still be content to show
     if (this.hasModalOutlet) return;
@@ -44,25 +44,31 @@ export default class Kpop__FrameController extends Controller {
   }
 
   openValueChanged(open) {
+    if (DEBUG) console.debug("frame:open-changed");
+
     this.element.style.display = open ? "flex" : "none";
   }
 
-  dismiss() {
-    if (DEBUG) console.debug("dismiss");
+  async dismiss() {
+    if (DEBUG) console.debug("frame:dismiss-start");
 
     if (!this.hasModalTarget || !this.openValue) return;
 
-    this.modalOutlet?.dismiss();
+    return this.modalOutlet?.dismiss();
   }
 
   async #openModal(scrim, modal) {
-    scrim.show(modal.scrimConfig).then(() => (this.openValue = true));
+    if (DEBUG) console.debug("frame:#open-start");
+    await modal.open(scrim);
+    this.openValue = true;
+    if (DEBUG) console.debug("frame:#open-end");
   }
 
   #clear() {
-    if (DEBUG) console.debug("#clear");
+    if (DEBUG) console.debug("frame:#clear");
 
     this.element.removeAttribute("src");
+    this.element.removeAttribute("complete");
     this.element.innerHTML = "";
   }
 

--- a/app/assets/javascripts/controllers/kpop/modal_controller.js
+++ b/app/assets/javascripts/controllers/kpop/modal_controller.js
@@ -1,6 +1,6 @@
 import { Controller } from "@hotwired/stimulus";
 
-const DEBUG = false;
+const DEBUG = true;
 
 export default class Kpop__ModalController extends Controller {
   static values = {
@@ -12,64 +12,110 @@ export default class Kpop__ModalController extends Controller {
   }
 
   connect() {
-    if (DEBUG) console.debug("modal connect");
+    if (DEBUG) console.debug("modal:connect");
 
     this.element.toggleAttribute("data-turbo-temporary", this.temporaryValue);
-
-    // Push a new history entry. This will be popped or replaced when the modal is dismissed.
-    // Persistent modals push a history entry via Turbo.
-    if (this.temporaryValue) {
-      window.history.pushState({}, "", window.location);
-    }
-
-    // Capture pops so we can dismiss the modal.
-    window.addEventListener("popstate", this.popstate);
-
-    // Capture visits so we can replace history.
-    window.addEventListener("turbo:before-visit", this.beforeVisit);
   }
 
   disconnect() {
-    if (DEBUG) console.debug("modal disconnect");
+    if (this.popped) return;
 
-    window.removeEventListener("popstate", this.popstate);
-    window.removeEventListener("turbo:before-visit", this.beforeVisit);
+    if (DEBUG) console.debug("modal:disconnect");
 
-    if (!this.popped) {
-      this.dismiss();
+    this.popped = true;
+    window.history.back();
+  }
+
+  async open(scrim) {
+    // Push a new history entry. This will be popped or replaced when the modal is dismissed.
+    // Persistent modals push a history entry via Turbo.
+    if (this.temporaryValue) {
+      if (DEBUG) console.debug("modal:push-state");
+      window.history.pushState(window.history.state, "", window.location);
+      scrim.show(this.scrimConfig);
+    } else {
+      return new Promise((resolve) => {
+        window.addEventListener(
+          "turbo:before-cache",
+          () => {
+            if (DEBUG) console.debug("modal:visit");
+            window.requestAnimationFrame(() => {
+              scrim.show(this.scrimConfig);
+              resolve();
+            });
+          },
+          { once: true },
+        );
+      });
     }
   }
 
-  dismiss() {
-    if (DEBUG) console.debug("modal dismiss");
+  async dismiss() {
+    if (this.popped) return;
 
-    if (!this.popped) {
-      this.popped = true;
-      window.history.back();
-    }
+    if (DEBUG) console.debug("modal:dismiss");
+    this.popped = true;
+
+    // set animation state
+    this.element.dataset.closing = "";
+
+    // callback for after animation has finished (driven by animation-duration in CSS)
+    return new Promise((resolve) => {
+      this.element.addEventListener(
+        "animationend",
+        () => {
+          if (DEBUG) console.debug("modal:dismiss-end");
+
+          const event = this.temporaryValue ? "popstate" : "turbo:render";
+          window.addEventListener(event, () => resolve(), { once: true });
+          window.history.back();
+        },
+        {
+          once: true,
+        },
+      );
+    });
   }
 
   popstate = () => {
     this.popped = true;
 
-    if (DEBUG) console.debug("modal popped");
+    if (DEBUG) console.debug("modal:popstate");
 
     // Remove the modal from the DOM if it's a temporary modal.
     if (this.temporaryValue) {
+      if (DEBUG) console.debug("modal:popstate-remove");
       this.element.remove();
     }
+  };
+
+  beforeCache = () => {
+    if (DEBUG) console.debug("modal:before-cache");
+
+    // Modal has already animated (if it's going to), we won't see another frame
+    // before turbo pops state, so we can safely restore the dom state to the
+    // "rendered" version.
+    delete this.element.dataset.closing;
   };
 
   beforeVisit = (e) => {
     if (this.popped) return;
 
+    if (DEBUG) console.debug("modal:before-visit");
+
     // visit fires when persistent modals load, so we need to ignore those.
     if (e.detail.url === this.element.closest("turbo-frame").src) return;
 
-    if (DEBUG) console.debug("visiting", e.detail.url);
+    if (DEBUG) console.debug("modal:visit", e.detail.url);
 
     e.preventDefault();
     this.popped = true;
-    Turbo.visit(e.detail.url, { action: "replace" });
+    if (this.temporaryValue) {
+      Turbo.visit(e.detail.url, { action: "replace" });
+    } else {
+      Turbo.visit(e.detail.url, { action: "advance" });
+    }
+
+    if (DEBUG) console.debug("modal:visit-end");
   };
 }

--- a/app/assets/javascripts/controllers/kpop/redirect_controller.js
+++ b/app/assets/javascripts/controllers/kpop/redirect_controller.js
@@ -2,12 +2,20 @@ import { Controller } from "@hotwired/stimulus";
 import { Turbo } from "@hotwired/turbo-rails";
 
 export default class Kpop__RedirectController extends Controller {
+  static outlets = ["kpop--frame"];
   static values = {
     path: String,
+    target: String,
   };
 
-  connect() {
-    Turbo.visit(this.pathValue);
+  kpopFrameOutletConnected(frame) {
+    if (this.targetValue === frame.element.id) {
+      frame.dismiss().then(() => {
+        document.getElementById(this.targetValue).src = this.pathValue;
+      });
+    } else {
+      Turbo.visit(this.pathValue, { action: "replace" });
+    }
 
     this.element.remove();
   }

--- a/app/assets/javascripts/controllers/scrim_controller.js
+++ b/app/assets/javascripts/controllers/scrim_controller.js
@@ -1,6 +1,6 @@
 import { Controller } from "@hotwired/stimulus";
 
-const DEBUG = false;
+const DEBUG = true;
 
 /**
  * Scrim controller wraps an element that creates a whole page layer.
@@ -21,21 +21,26 @@ export default class ScrimController extends Controller {
   };
 
   connect() {
+    if (DEBUG) console.debug("scrim:connect");
+
     this.defaultZIndexValue = this.zIndexValue;
     this.defaultCaptiveValue = this.captiveValue;
     this.defaultTemporaryValue = this.temporaryValue;
   }
 
-  async show({
+  show({
     captive = this.defaultCaptiveValue,
     zIndex = this.defaultZIndexValue,
     top = window.scrollY,
     temporary = this.defaultTemporaryValue,
   } = {}) {
-    if (DEBUG) console.debug("request show scrim");
+    if (DEBUG) console.debug("scrim:before-show");
 
     // hide the scrim before opening the new one if it's already open
-    if (this.openValue) await this.hide();
+    if (this.openValue) {
+      this.hide();
+      delete this.element.dataset.hideAnimating; // cancel hide animation
+    }
 
     // if the scrim is still open, abort
     if (this.openValue) return;
@@ -46,16 +51,20 @@ export default class ScrimController extends Controller {
     // notify listeners of pending request
     this.dispatch("show", { bubbles: true });
 
-    if (DEBUG) console.debug("show scrim");
+    if (DEBUG) console.debug("scrim:show-start");
 
     // update state, perform style updates
-    return this.#show(captive, zIndex, top, temporary);
+    this.#show(captive, zIndex, top, temporary);
+
+    // animate opening
+    // this will trigger an animationEnd event via CSS that completes the open
+    this.element.dataset.showAnimating = "";
   }
 
-  async hide() {
+  hide() {
     if (!this.openValue) return;
 
-    if (DEBUG) console.debug("request hide scrim");
+    if (DEBUG) console.debug("scrim:before-hide");
 
     // update internal state to break event cycles
     this.openValue = false;
@@ -63,29 +72,60 @@ export default class ScrimController extends Controller {
     // notify listeners of pending request
     this.dispatch("hide", { bubbles: true });
 
-    if (DEBUG) console.debug("hide scrim");
+    if (DEBUG) console.debug("scrim:hide-start");
 
-    // update state, perform style updates
-    return this.#hide();
+    // set animation state
+    // this will trigger an animationEnd event via CSS that completes the hide
+    this.element.dataset.hideAnimating = "";
   }
 
   beforeCache() {
+    if (DEBUG) console.debug("scrim:before-cache");
+
+    // hide the scrim if the current modal is not cacheable
     if (this.temporaryValue) this.hide();
+
+    // jump directly to the end-state of the animation, if any
+    this.animationEnd();
   }
 
   dismiss(event) {
-    if (!this.captiveValue) this.hide();
+    if (DEBUG) console.debug("scrim:dismiss");
+
+    if (!this.captiveValue) this.dispatch("dismiss", { bubbles: true });
   }
 
   escape(event) {
-    if (event.key === "Escape" && !this.captiveValue && !event.defaultPrevented)
-      this.hide();
+    if (
+      event.key === "Escape" &&
+      !this.captiveValue &&
+      !event.defaultPrevented
+    ) {
+      this.dispatch("dismiss", { bubbles: true });
+    }
+  }
+
+  animationEnd() {
+    if (this.element.dataset.hideAnimating === "") {
+      if (DEBUG) console.debug("scrim:hide-end");
+      delete this.element.dataset.hideAnimating;
+
+      // update state, perform style updates
+      this.#hide();
+
+      if (DEBUG) console.debug("scrim:#hide-end");
+    }
+
+    if (this.element.dataset.showAnimating === "") {
+      if (DEBUG) console.debug("scrim:show-end");
+      delete this.element.dataset.showAnimating;
+    }
   }
 
   /**
    * Clips body to viewport size and sets the z-index
    */
-  async #show(captive, zIndex, top, temporary) {
+  #show(captive, zIndex, top, temporary) {
     this.captiveValue = captive;
     this.zIndexValue = zIndex;
     this.scrollY = top;
@@ -102,7 +142,7 @@ export default class ScrimController extends Controller {
   /**
    * Unclips body from viewport size and unsets the z-index
    */
-  async #hide() {
+  #hide() {
     this.captiveValue = this.defaultCaptiveValue;
     this.zIndexValue = this.defaultZIndexValue;
     this.temporaryValue = this.defaultTemporaryValue;
@@ -110,6 +150,7 @@ export default class ScrimController extends Controller {
     resetStyle(this.element, "z-index", null);
     resetStyle(document.body, "position", null);
     resetStyle(document.body, "top", null);
+
     window.scrollTo({ left: 0, top: this.scrollY, behavior: "instant" });
 
     delete this.scrollY;

--- a/app/assets/stylesheets/katalyst/kpop/_index.scss
+++ b/app/assets/stylesheets/katalyst/kpop/_index.scss
@@ -1,2 +1,9 @@
-@use "kpop";
-@use "scrim";
+$duration: 0.2s;
+
+@use "kpop" with (
+  $duration: $duration
+);
+@use "side_panel";
+@use "scrim" with (
+  $duration: $duration
+);

--- a/app/assets/stylesheets/katalyst/kpop/_kpop.scss
+++ b/app/assets/stylesheets/katalyst/kpop/_kpop.scss
@@ -6,6 +6,8 @@ $min-height: 0 !default;
 $max-height: 80vh !default;
 $default-padding: 1rem 1.5rem !default;
 
+$duration: 0.2s !default;
+
 .kpop-container {
   display: none;
 
@@ -15,7 +17,6 @@ $default-padding: 1rem 1.5rem !default;
   right: 0;
   bottom: 0;
 
-  justify-content: center;
   align-items: center;
   z-index: 1000;
   pointer-events: none;
@@ -23,11 +24,21 @@ $default-padding: 1rem 1.5rem !default;
   > * {
     pointer-events: auto;
   }
+
+  .kpop-modal[data-closing] {
+    animation: var(--closing-animation);
+    animation-duration: $duration;
+    animation-fill-mode: forwards;
+  }
 }
 
 .kpop-modal {
+  --opening-animation: slide-in-up;
+  --closing-animation: slide-out-down;
+
   position: relative;
   overflow: hidden;
+  margin: 0 auto;
 
   display: grid;
   grid-template-areas:
@@ -95,6 +106,12 @@ $default-padding: 1rem 1.5rem !default;
   }
 }
 
+.scrim[data-show-animating] + .kpop-container .kpop-modal {
+  animation: var(--opening-animation);
+  animation-duration: $duration;
+  animation-fill-mode: forwards;
+}
+
 .kpop-modal.iframe {
   .kpop-content {
     overflow: unset;
@@ -129,5 +146,27 @@ $default-padding: 1rem 1.5rem !default;
   .kpop-buttons {
     flex-direction: column-reverse;
     text-align: center;
+  }
+}
+
+@keyframes slide-in-up {
+  0% {
+    transform: translateY(10%);
+    opacity: 0;
+  }
+  100% {
+    transform: translateY(0%);
+    opacity: 1;
+  }
+}
+
+@keyframes slide-out-down {
+  0% {
+    transform: translateY(0%);
+    opacity: 1;
+  }
+  100% {
+    transform: translateY(10%);
+    opacity: 0;
   }
 }

--- a/app/assets/stylesheets/katalyst/kpop/_scrim.scss
+++ b/app/assets/stylesheets/katalyst/kpop/_scrim.scss
@@ -1,3 +1,5 @@
+$duration: 0.2s !default;
+
 .scrim {
   position: fixed;
   top: 0;
@@ -6,15 +8,35 @@
   right: 0;
   background: rgba(0, 0, 0, 0.6);
   z-index: -1;
-  transition:
-    opacity 0.2s ease-in-out,
-    z-index 0.2s step-end;
   opacity: 0;
+
+  &[data-hide-animating] {
+    animation: fade-out;
+    animation-duration: $duration;
+    animation-fill-mode: forwards;
+  }
 }
 
 .scrim[data-scrim-open-value="true"] {
-  opacity: 1;
-  transition:
-    opacity 0.2s ease-in-out,
-    z-index 0.2s step-start;
+  animation: fade-in;
+  animation-duration: $duration;
+  animation-fill-mode: forwards;
+}
+
+@keyframes fade-in {
+  0% {
+    opacity: 0;
+  }
+  100% {
+    opacity: 1;
+  }
+}
+
+@keyframes fade-out {
+  0% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0;
+  }
 }

--- a/app/assets/stylesheets/katalyst/kpop/_side_panel.scss
+++ b/app/assets/stylesheets/katalyst/kpop/_side_panel.scss
@@ -1,0 +1,58 @@
+.kpop-modal.kpop-side-panel {
+  --opening-animation: slide-in-right;
+  --closing-animation: slide-out-right;
+  width: 50%;
+  max-width: unset;
+  max-height: unset;
+  height: 100%;
+  margin-inline: auto 0;
+  border-radius: 0;
+  border: 0;
+}
+
+@media (max-width: 600px), (max-height: 600px) {
+  .kpop-modal.kpop-side-panel {
+    --opening-animation: slide-in-bottom;
+    --closing-animation: slide-out-bottom;
+    max-width: unset;
+    min-width: unset;
+    width: 100%;
+    height: 100%;
+  }
+}
+
+@keyframes slide-in-right {
+  0% {
+    transform: translateX(100%);
+  }
+  100% {
+    transform: translateX(0%);
+  }
+}
+
+@keyframes slide-out-right {
+  0% {
+    transform: translateX(0%);
+  }
+  100% {
+    transform: translateX(100%);
+  }
+}
+
+@keyframes slide-in-bottom {
+  0% {
+    transform: translateY(100%);
+  }
+  100% {
+    transform: translateY(0%);
+  }
+}
+
+@keyframes slide-out-bottom {
+  0% {
+    transform: translateY(0%);
+  }
+  100% {
+    transform: translateY(100%);
+  }
+}

--- a/app/components/kpop/frame_component.html.erb
+++ b/app/components/kpop/frame_component.html.erb
@@ -1,3 +1,12 @@
 <%= turbo_frame_tag(id, **html_attributes) do %>
   <%= content %>
+  <% if flash[:kpop] %>
+    <%= tag.div("", data: {
+                  controller:                        "kpop--redirect",
+                  kpop__redirect_kpop__frame_outlet: "##{id}",
+                  kpop__redirect_path_value:         flash[:kpop],
+                  kpop__redirect_target_value:       id,
+                  turbo_temporary:                   "",
+                }) %>
+  <% end %>
 <% end %>

--- a/app/components/kpop/frame_component.rb
+++ b/app/components/kpop/frame_component.rb
@@ -8,6 +8,7 @@ module Kpop
     attr_reader :id
 
     ACTIONS = %w[
+      scrim:dismiss@window->kpop--frame#dismiss
       scrim:hide@window->kpop--frame#dismiss
     ].freeze
 

--- a/app/components/kpop/modal_component.rb
+++ b/app/components/kpop/modal_component.rb
@@ -14,9 +14,10 @@ module Kpop
     renders_one :header
     renders_one :footer
 
-    def initialize(title:, captive: false, temporary: true, **)
+    def initialize(title:, captive: false, temporary: true, dismiss: nil, **)
       super
 
+      @dismiss   = dismiss
       @temporary = temporary
 
       # Generate a title bar. This can be overridden by calling title_bar again.
@@ -36,6 +37,7 @@ module Kpop
           controller:                    "kpop--modal",
           action:                        ACTIONS.join(" "),
           "kpop--frame-target":          "modal",
+          "kpop--modal-dismiss-value":   @dismiss,
           "kpop--modal-temporary-value": @temporary,
         },
       }

--- a/app/components/kpop/modal_component.rb
+++ b/app/components/kpop/modal_component.rb
@@ -4,6 +4,12 @@ module Kpop
   class ModalComponent < ViewComponent::Base
     include HasHtmlAttributes
 
+    ACTIONS = %w[
+      popstate@window->kpop--modal#popstate
+      turbo:before-cache@window->kpop--modal#beforeCache
+      turbo:before-visit@window->kpop--modal#beforeVisit
+    ].freeze
+
     renders_one :title, "Kpop::Modal::TitleComponent"
     renders_one :header
     renders_one :footer
@@ -28,6 +34,7 @@ module Kpop
         class: "kpop-modal",
         data:  {
           controller:                    "kpop--modal",
+          action:                        ACTIONS.join(" "),
           "kpop--frame-target":          "modal",
           "kpop--modal-temporary-value": @temporary,
         },

--- a/app/components/scrim_component.rb
+++ b/app/components/scrim_component.rb
@@ -4,10 +4,9 @@ class ScrimComponent < ViewComponent::Base
   attr_reader :id, :z_index
 
   ACTIONS = %w[
+    animationend->scrim#animationEnd
     click->scrim#dismiss
     keyup@window->scrim#escape
-    scrim:request:hide@window->scrim#hide
-    scrim:request:show@window->scrim#show
     turbo:before-cache@document->scrim#beforeCache
   ].freeze
 

--- a/app/helpers/kpop_helper.rb
+++ b/app/helpers/kpop_helper.rb
@@ -3,12 +3,6 @@
 module KpopHelper
   using HTMLAttributesUtils
 
-  # Render a modal dialog. Intended for use inside a kpop turbo frame tag.
-  # See builder for options.
-  def render_kpop(options = {}, &)
-    render(Kpop::ModalComponent.new(**options), &)
-  end
-
   # Render a turbo stream action that will dismiss any open kpop modals.
   def kpop_dismiss(id: "kpop")
     turbo_stream.append(id) do

--- a/app/helpers/kpop_helper.rb
+++ b/app/helpers/kpop_helper.rb
@@ -11,7 +11,26 @@ module KpopHelper
 
   # Render a turbo stream action that will dismiss any open kpop modals.
   def kpop_dismiss(id: "kpop")
-    turbo_stream.update(id, "")
+    turbo_stream.append(id) do
+      tag.div("", data: {
+                controller:                     "kpop--close",
+                kpop__close_kpop__frame_outlet: "##{id}",
+                turbo_temporary:                "",
+              })
+    end
+  end
+
+  # Renders a kpop redirect controller response that will escape the frame and navigate to the given URL.
+  def kpop_redirect_to(url, id: "kpop", target: nil)
+    turbo_stream.append(id) do
+      tag.div("", data: {
+                controller:                        "kpop--redirect",
+                kpop__redirect_kpop__frame_outlet: "##{id}",
+                kpop__redirect_path_value:         url,
+                kpop__redirect_target_value:       target,
+                turbo_temporary:                   "",
+              })
+    end
   end
 
   # Renders a link that will navigate the kpop turbo frame to the given URL.
@@ -23,13 +42,6 @@ module KpopHelper
       link_to(name, default_html_attributes.deep_merge_html_attributes(options || {}), &block)
     else
       link_to(name, options, default_html_attributes.deep_merge_html_attributes(html_attributes || {}))
-    end
-  end
-
-  # Renders a kpop redirect controller response that will escape the frame and navigate to the given URL.
-  def kpop_redirect_to(url, id: "kpop")
-    turbo_stream.append(id) do
-      tag.div("", data: { controller: "kpop--redirect", kpop__redirect_path_value: url })
     end
   end
 

--- a/lib/kpop/matchers/kpop_dismiss.rb
+++ b/lib/kpop/matchers/kpop_dismiss.rb
@@ -37,7 +37,7 @@ module Kpop
     def kpop_dismiss(id: "kpop")
       ChainedMatcher.new(ResponseMatcher.new,
                          CapybaraParser,
-                         StreamMatcher.new(id:, action: "update"))
+                         StreamMatcher.new(id:, action: "append"))
     end
   end
 end

--- a/spec/dummy/app/controllers/modals_controller.rb
+++ b/spec/dummy/app/controllers/modals_controller.rb
@@ -8,7 +8,10 @@ class ModalsController < ApplicationController
   end
 
   def persistent
-    redirect_to root_path, status: :see_other unless request.headers["Turbo-Frame"] == "kpop"
+    unless request.headers["Turbo-Frame"] == "kpop"
+      @dismiss = root_path
+      render "home/index", layout: "application", locals: { kpop: "modals/persistent" }
+    end
   end
 
   def update

--- a/spec/dummy/app/controllers/modals_controller.rb
+++ b/spec/dummy/app/controllers/modals_controller.rb
@@ -17,6 +17,10 @@ class ModalsController < ApplicationController
       close_modal
     when "test"
       redirect_forwards
+    when "anonymous"
+      render turbo_stream: helpers.kpop_redirect_to(anonymous_modal_path, target: "kpop")
+    when "persistent"
+      render turbo_stream: helpers.kpop_redirect_to(persistent_modal_path, target: "kpop")
     else
       @error = true
       render status: :unprocessable_entity

--- a/spec/dummy/app/views/home/index.html.erb
+++ b/spec/dummy/app/views/home/index.html.erb
@@ -4,3 +4,9 @@
   <li><%= kpop_link_to "Anonymous Modal", anonymous_modal_path %></li>
   <li><%= kpop_link_to "Persistent Modal", persistent_modal_path, data: { turbo_action: "advance" } %></li>
 </ul>
+
+<% if local_assigns[:kpop] %>
+  <% content_for(:kpop) do %>
+    <%= render template: kpop %>
+  <% end %>
+<% end %>

--- a/spec/dummy/app/views/modals/_form.html.erb
+++ b/spec/dummy/app/views/modals/_form.html.erb
@@ -1,7 +1,7 @@
 <%= form_with(id: "form", url: modal_path, method: :patch, scope: "", data: { turbo_frame: "kpop" }) do |form| %>
   <%= "Form is invalid" if @error %>
   <%= form.label :next %>
-  <%= form.collection_select :next, %w[home test error], :itself, :itself %>
+  <%= form.collection_select :next, %w[home test error anonymous persistent], :itself, :itself %>
   <%= form.hidden_field :template, value: "anonymous" %>
   <%= form.submit %>
 <% end %>

--- a/spec/dummy/app/views/modals/persistent.html.erb
+++ b/spec/dummy/app/views/modals/persistent.html.erb
@@ -1,4 +1,4 @@
-<%= render Kpop::ModalComponent.new(title: "Persistent modal", temporary: false) do %>
+<%= render Kpop::ModalComponent.new(title: "Persistent modal", class: "kpop-side-panel", temporary: false) do %>
   Modal content
   <a href="/">Home</a>
   <a href="/test">Test</a>

--- a/spec/dummy/app/views/modals/persistent.html.erb
+++ b/spec/dummy/app/views/modals/persistent.html.erb
@@ -1,4 +1,4 @@
-<%= render Kpop::ModalComponent.new(title: "Persistent modal", class: "kpop-side-panel", temporary: false) do %>
+<%= render Kpop::ModalComponent.new(title: "Persistent modal", class: "kpop-side-panel", temporary: false, dismiss: @dismiss) do %>
   Modal content
   <a href="/">Home</a>
   <a href="/test">Test</a>

--- a/spec/system/anonymous_modal_spec.rb
+++ b/spec/system/anonymous_modal_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "Anonymous modal" do
     click_link("Anonymous")
 
     # Wait for modal to render
-    find(".kpop-modal")
+    find("[data-kpop--frame-open-value='true'] .kpop-modal")
   end
 
   context "when opening from URL" do
@@ -51,6 +51,8 @@ RSpec.describe "Anonymous modal" do
     end
 
     it "supports scrim closing" do
+      sleep 0.1
+
       # Clicking the scrim closes the modal
       find_by_id("scrim").trigger("click")
 

--- a/spec/system/persistent_modal_spec.rb
+++ b/spec/system/persistent_modal_spec.rb
@@ -95,7 +95,12 @@ RSpec.describe "Persistent modal" do
       expect(page).to have_current_path(test_path)
       expect(page).not_to have_css(".kpop-modal")
 
-      # Clicking the back button to go back home
+      # Clicking the back button to go back to the modal
+      page.go_back
+
+      expect(page).to have_current_path(persistent_modal_path)
+
+      # Clicking the back button to go back to the root
       page.go_back
 
       expect(page).to have_current_path(root_path)
@@ -132,6 +137,11 @@ RSpec.describe "Persistent modal" do
       expect(page).to have_current_path(test_path)
       expect(page).not_to have_css(".kpop-modal")
 
+      # Clicking the back button to go back to the modal
+      page.go_back
+
+      expect(page).to have_current_path(persistent_modal_path)
+
       # Click the back button to return to root
       page.go_back
 
@@ -163,6 +173,46 @@ RSpec.describe "Persistent modal" do
       expect(page).not_to have_css(".kpop-modal")
 
       # Click the back button to show no extra history was added
+      page.go_back
+
+      expect(page).to have_current_path(nil)
+    end
+
+    it "supports navigation re-opening after submit" do
+      # Fill in the form
+      within(".kpop-modal") do |_kpop|
+        select "home", from: "Next"
+        click_button "Save"
+      end
+
+      expect(page).to have_current_path(root_path)
+      expect(page).not_to have_css(".kpop-modal")
+
+      # Clicking forward re-opens the modal
+      page.go_forward
+
+      expect(page).to have_current_path(persistent_modal_path)
+      within(".kpop-modal") do |kpop|
+        expect(kpop).to have_content("Persistent modal")
+      end
+    end
+
+    it "supports rendering a new modal via form submission" do
+      # Fill in the form
+      within(".kpop-modal") do |_kpop|
+        select "anonymous", from: "Next"
+        click_button "Save"
+      end
+
+      expect(page).to have_current_path(root_path)
+      expect(page).to have_css(".kpop-title", text: "Anonymous modal")
+
+      # Clicking the back button to go back to the root path
+      page.go_back
+
+      expect(page).to have_current_path(root_path)
+
+      # Click the back button again to show no extra history was added
       page.go_back
 
       expect(page).to have_current_path(nil)

--- a/spec/system/persistent_modal_spec.rb
+++ b/spec/system/persistent_modal_spec.rb
@@ -3,17 +3,17 @@
 require "rails_helper"
 
 RSpec.describe "Persistent modal" do
-  before do
-    visit root_path
-
-    # Open modal
-    click_link("Persistent")
-
-    # Wait for modal to render
-    find("[data-kpop--frame-open-value='true']")
-  end
-
   context "when opening from URL" do
+    before do
+      visit root_path
+
+      # Open modal
+      click_link("Persistent")
+
+      # Wait for modal to render
+      find("[data-kpop--frame-open-value='true']")
+    end
+
     it "opens successfully" do
       # Modal shows
       within(".kpop-modal") do |kpop|
@@ -213,6 +213,32 @@ RSpec.describe "Persistent modal" do
       expect(page).to have_current_path(root_path)
 
       # Click the back button again to show no extra history was added
+      page.go_back
+
+      expect(page).to have_current_path(nil)
+    end
+  end
+
+  context "when navigating to modal URL" do
+    before do
+      visit persistent_modal_path
+
+      # Wait for modal to render
+      find("[data-kpop--frame-open-value='true']")
+    end
+
+    it "supports form errors on form submission" do
+      expect(page).to have_current_path(persistent_modal_path) # url is modal url
+      expect(page).to have_content("Hello world!") # root page is rendered in the background
+
+      # Clicking the close button closes the modal
+      find(".kpop-close").click
+
+      expect(page).to have_current_path(root_path)
+      expect(page).not_to have_css(".kpop-modal")
+
+      # Click the back button leaves the site
+      # Note: this is not ideal, but otherwise would need to know if modal is persistent or not
       page.go_back
 
       expect(page).to have_current_path(nil)


### PR DESCRIPTION
Allow for scrim to wait for closing animation of modal before dismissing the scrim
Only animate modal content while the scrim is also in its opening animation
- Stops consecutive modals from animating in when navigating without closing the scrim