### PR TITLE
Add support for eager-loading Kpop

### DIFF
--- a/lib/katalyst/kpop.rb
+++ b/lib/katalyst/kpop.rb
@@ -8,5 +8,6 @@ require "katalyst/kpop/turbo"
 
 module Katalyst
   module Kpop
+    extend ActiveSupport::Autoload
   end
 end


### PR DESCRIPTION
* On the Kpop::Engine we have set `config.eager_load_namespaces << Katalyst::Kpop` which requires `Katalyst::Kpop` module to include `eager_load!` method, provided by extending `ActiveSupport::Autoload`