### PR TITLE
Fixed width side panel

### DIFF
--- a/app/assets/stylesheets/katalyst/kpop/_side_panel.scss
+++ b/app/assets/stylesheets/katalyst/kpop/_side_panel.scss
@@ -3,8 +3,8 @@
 .kpop--frame.side-panel {
   --opening-animation: slide-in-right;
   --closing-animation: slide-out-right;
-  --min-width: 30dvw;
-  --max-width: 50dvw;
+  --min-width: 35dvw;
+  --max-width: calc(100dvw - 4rem);
   --min-height: 100dvh;
   --max-height: 100dvh;
 


### PR DESCRIPTION
Use the mobile width to create a smooth transition into mobile mode.

Addresses request in https://github.com/katalyst/koi/issues/609